### PR TITLE
Enable cops to enforce preference for default array syntax

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -44,3 +44,11 @@ Style/StringLiteralsInInterpolation:
 
 Layout/DotPosition:
   EnforcedStyle: trailing
+
+Style/SymbolArray:
+  Enabled: true
+  EnforcedStyle: brackets
+  
+Style/WordArray:
+  Enabled: true
+  EnforcedStyle: brackets


### PR DESCRIPTION
Since we point new devs to this repo as the source of truth for style rules and we also have this installed across all of our microservices, we should be including any base rules that we try and adhere to across the board.

This PR adds our explicit preference for standard square bracket array syntax, as described below:

```ruby
# good
[:foo, :bar, :baz]

# bad
%i[foo bar baz]
```
```ruby
# good
['foo', 'bar', 'baz']

# bad
%w[foo bar baz]
```