### PR TITLE
[SRE-146] Publish on GitHub Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,27 @@ This gem holds a shared rubocop config for Smile.io Ruby repositories.
 Installing the gem will also install a version of Rubocop compatible with this
 config.
 
+## Bundler Authentication
+
+This gem is hosted on Github Packages, so you will need to configure bundler to use a github access token in order to install it.
+
+_Note:_ If running `bundle config | grep rubygems.pkg.github.com/smile-io` returns `https://rubygems.pkg.github.com/smile-io/` you've likely already completed this step, and can skip forward to [Installation](#installation).
+
+1) [Create a Github Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)
+
+2) Execute:
+```bash
+bundle config https://rubygems.pkg.github.com/smile-io USERNAME:TOKEN
+```
+(replacing `USERNAME` with your github username, and `TOKEN` with your new access token)
+
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-source "https://gem.fury.io/smileio/" do
-  gem 'smile_rubocop'
+source "https://rubygems.pkg.github.com/smile-io" do
+  gem "smile_rubocop"
 end
 ```
 

--- a/lib/smile_rubocop/version.rb
+++ b/lib/smile_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SmileRubocop
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/smile_rubocop.gemspec
+++ b/smile_rubocop.gemspec
@@ -7,12 +7,13 @@ Gem::Specification.new do |spec|
   spec.email         = ["alexw@smile.io"]
 
   spec.summary       = "Smile.io shared rubocop config."
-  spec.homepage      = "https://www.smile.io"
+  spec.homepage      = "https://www.github.com/smile-io/smile-rubocop"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "https://TODO: Set to 'http://mygemserver.com'"
+    spec.metadata["github_repo"] = "ssh://github.com/smile-io/smile-rubocop"
+    spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com/smile-io/smile-rubocop"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."


### PR DESCRIPTION
This PR updates necessary files for this gem to be published on GitHub packages.
I took as example metadata the specs from smile-monitoring.

- Update gem metadata
- Update README.md
- Bump gem version to 0.1.3