### PR TITLE
Make rubocop version be less strict so we can install it on smile-core

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,36 @@
 PATH
   remote: .
   specs:
-    smile_rubocop_config (0.1.0)
-      rubocop (= 0.52)
+    smile_rubocop (0.1.4)
+      rubocop (~> 0.52)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    parallel (1.12.1)
-    parser (2.5.1.0)
+    jaro_winkler (1.5.4)
+    parallel (1.19.1)
+    parser (2.7.1.1)
       ast (~> 2.4.0)
-    powerpack (0.1.1)
     rainbow (3.0.0)
-    rubocop (0.52.0)
+    rexml (3.2.4)
+    rubocop (0.82.0)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.4.0.2, < 3.0)
-      powerpack (~> 0.1)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
-    unicode-display_width (1.3.2)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 1.16)
-  smile_rubocop_config!
+  smile_rubocop!
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/default.yml
+++ b/default.yml
@@ -48,7 +48,7 @@ Layout/DotPosition:
 Style/SymbolArray:
   Enabled: true
   EnforcedStyle: brackets
-  
+
 Style/WordArray:
   Enabled: true
   EnforcedStyle: brackets

--- a/lib/smile_rubocop/version.rb
+++ b/lib/smile_rubocop/version.rb
@@ -1,3 +1,3 @@
 module SmileRubocop
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/smile_rubocop.gemspec
+++ b/smile_rubocop.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "0.52"
+  spec.add_dependency "rubocop", "~> 0.52"
 
   spec.add_development_dependency "bundler", "~> 1.16"
 end


### PR DESCRIPTION
I tried to install this gem on smile-core and I got this error because the rubocop version in this gem is very strict.

![Screen Shot 2020-04-30 at 6 57 53 PM](https://user-images.githubusercontent.com/2293178/80766931-97c37f80-8b14-11ea-93af-a3a822adddd8.png)

After this PR, we will be able to install it on smile core and lint smile core with the rules defined here.

![Screen Shot 2020-04-30 at 6 52 49 PM](https://user-images.githubusercontent.com/2293178/80766929-972ae900-8b14-11ea-9006-a1edfce672cd.png)



